### PR TITLE
Correction: Missing collection of data

### DIFF
--- a/datasets/simulateExample.R
+++ b/datasets/simulateExample.R
@@ -112,6 +112,7 @@ for (generation in 1:10) {
 # but add also continually admixed population selected on an index
 popAB <- randCross(pop = c(parentsA, parentsB), nCrosses = 50)
 popAB <- setPheno(pop = popAB, varE = diag(varE))
+data <- collectData(pop = popAB, data = data, population = "AB", generation = generation)
 economicWeights <- c(1, 1)
 selIndexWeights <- smithHazel(econWt = economicWeights, varG = varG, varP = varG + varE)
 for (generation in 11:20) {


### PR DESCRIPTION
I added a line to collect the data from the first A and B cross (popAB) in the simulation. Without it, 50 individual records, some of which were parents, were missing from the simulated recorded pedigree. 